### PR TITLE
fix(security): Escape externally sourced data for admin display

### DIFF
--- a/ProcessWireMailBrevo.module
+++ b/ProcessWireMailBrevo.module
@@ -122,9 +122,9 @@ class ProcessWireMailBrevo extends Process
                         [
                             "<span class='label $event_label'>$log->event</span>",
                             '<span style="display:none">' . $log->date . '</span>' . $readable_time,
-                            $log->subject,
-                            $log->from,
-                            $log->email,
+                            wire()->sanitizer->entities($log->subject),
+                            wire()->sanitizer->entities($log->from),
+                            wire()->sanitizer->entities($log->email),
                             isset($log->templateId) ? $log->templateId : '',
 
 


### PR DESCRIPTION
Hello Timothy,

As data in this table is coming from an external source, and entity escaping has been disabled on our table (L78), we need to do our own escaping of externally supplied data as email addresses and subject lines can have strings that have HTML special chars in them.

You might want to review this PR for sanity, as I don't know if the Brevo API provides data that is already escaped for HTML context, or just gives you raw strings.